### PR TITLE
remove Perl6::Export:::Attrs requirement

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -2,7 +2,6 @@ requires 'Carp', '1.17';
 requires 'Net::IDN::Encode', '2.003';
 requires 'Net::IDN::Nameprep', '1.101';
 requires 'Net::IDN::Punycode', '1.100';
-requires 'Perl6::Export::Attrs';
 requires 'Modern::Perl';
 requires 'utf8::all';
  

--- a/lib/ParseUtil/Domain.pm
+++ b/lib/ParseUtil/Domain.pm
@@ -2,21 +2,25 @@ package ParseUtil::Domain;
 
 # VERSION
 
+require Exporter;
+our @ISA = qw(Exporter);
+
 use Modern::Perl;
 use Carp;
 use utf8::all;
 use autobox;
 use autobox::Core;
 use List::MoreUtils qw/any/;
-use Perl6::Export::Attrs;
 use Net::IDN::Encode ':all';
 use Net::IDN::Punycode ':all';
 use Net::IDN::Nameprep;
 #use Smart::Comments;
 
 use ParseUtil::Domain::ConfigData;
+our @EXPORT = qw(parse_domain puny_convert);
+our %EXPORT_TAGS = (parse => [qw/parse_domain/], simple => [qw/puny_convert/]);
 
-sub parse_domain : Export(:parse) {
+sub parse_domain  {
     my $name = shift;
     ### testing : $name
     my @name_segments = $name->split(qr{\Q@\E});
@@ -58,7 +62,7 @@ sub parse_domain : Export(:parse) {
 
 }
 
-sub puny_convert : Export(:simple) {
+sub puny_convert {
     my $domain = shift;
     my @keys;
     if ( $domain =~ /\.?xn--/ ) {


### PR DESCRIPTION
Fails to install and crashes tests due to unspecified dependency.