### PR TITLE
Remove autobox usage.

### DIFF
--- a/lib/ParseUtil/Domain.pm
+++ b/lib/ParseUtil/Domain.pm
@@ -20,7 +20,7 @@ our %EXPORT_TAGS = (parse => [qw/parse_domain/], simple => [qw/puny_convert/]);
 sub parse_domain  {
     my $name = shift;
     ### testing : $name
-    my @name_segments = split qr{\Q@\E}, $name;
+    my @name_segments = split '@', $name;
     ### namesegments : \@name_segments
 
     my @segments = split qr/[\.\x{FF0E}\x{3002}\x{FF61}]/, $name_segments[-1];

--- a/lib/ParseUtil/Domain.pm
+++ b/lib/ParseUtil/Domain.pm
@@ -26,7 +26,7 @@ sub parse_domain  {
     my @segments = split qr/[\.\x{FF0E}\x{3002}\x{FF61}]/, $name_segments[-1];
     ### executing with : $name
     my ( $zone, $zone_ace, $domain_segments ) =
-        @{ _find_zone( \@segments ) }{qw/zone zone_ace domain/};
+      @{ _find_zone( \@segments ) }{qw/zone zone_ace domain/};
 
     ### found zone : $zone
     ### found zone_ace : $zone_ace


### PR DESCRIPTION
It was used somewhat inconsistently, and IMO isn't necessary; more annoyingly, though, it
was causing our code that uses ParseUtil::Domain to fail under the debugger,
because of scrottie/autobox-Core#34

Fully understand if you don't want to accept this  PR and keep the autobox syntax, but as it causes a problem and isn't really necessary (and as mentioned, some of the code used autobox methods and some used normal Perl, anyway) I thought I'd submit a PR that removes it, and see what you think.

The changes in this PR stop our code exploding under the debugger, and all the tests still pass for me.